### PR TITLE
Resolve compiler warnings related to function/variable ambiguity

### DIFF
--- a/lib/maybe.ex
+++ b/lib/maybe.ex
@@ -2,11 +2,11 @@ defmodule Maybe do
   def wrap(m = {:just, _}), do: m
   def wrap(m = :nothing), do: m
 
-  def wrap(nil), do: nothing
+  def wrap(nil), do: nothing()
   def wrap(v), do: just(v)
 
   def unwrap({:just, v}), do: unwrap(v)
-  def unwrap(:nothing), do: nothing
+  def unwrap(:nothing), do: nothing()
   def unwrap(v), do: v
 
   def just(v), do: {:just, unwrap(v)}

--- a/lib/result.ex
+++ b/lib/result.ex
@@ -2,8 +2,8 @@ defmodule Result do
   def wrap(m = {:ok, _}), do: m
   def wrap(m = {:error, _}), do: m
 
-  def wrap(nil), do: error
-  def wrap(:error), do: error
+  def wrap(nil), do: error()
+  def wrap(:error), do: error()
   def wrap(v), do: ok(v)
 
   def unwrap({t, v}) when t in [:ok, :error], do: unwrap(v)

--- a/mix.exs
+++ b/mix.exs
@@ -6,10 +6,10 @@ defmodule Towel.Mixfile do
      description: "A delightfully simple monad library that's written for Elixir.",
      version: "0.2.1",
      elixir: "~> 1.0",
-     package: package,
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def package do


### PR DESCRIPTION
For example: 

```
warning: variable "error" does not exist and is being expanded to "error()", please use parentheses to remove the ambiguity or change the variable name
  lib/result.ex:6
```